### PR TITLE
ZuulRateLimitFilter behaved differently than ServletRateLimit filter

### DIFF
--- a/bucket4j-spring-boot-starter/pom.xml
+++ b/bucket4j-spring-boot-starter/pom.xml
@@ -60,5 +60,22 @@
 			<artifactId>spring-boot-configuration-processor</artifactId>
 			<optional>true</optional>
 		</dependency>
+		<dependency>
+			<groupId>org.spockframework</groupId>
+			<artifactId>spock-core</artifactId>
+			<version>1.1-groovy-2.4</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.spockframework</groupId>
+			<artifactId>spock-spring</artifactId>
+			<version>1.1-groovy-2.4</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-test</artifactId>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 </project>

--- a/bucket4j-spring-boot-starter/src/main/java/com/giffing/bucket4j/spring/boot/starter/zuul/ZuulRateLimitFilter.java
+++ b/bucket4j-spring-boot-starter/src/main/java/com/giffing/bucket4j/spring/boot/starter/zuul/ZuulRateLimitFilter.java
@@ -1,18 +1,16 @@
 package com.giffing.bucket4j.spring.boot.starter.zuul;
 
-import javax.servlet.http.HttpServletRequest;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.http.HttpStatus;
-
 import com.giffing.bucket4j.spring.boot.starter.context.FilterConfiguration;
 import com.giffing.bucket4j.spring.boot.starter.context.RateLimitCheck;
 import com.giffing.bucket4j.spring.boot.starter.context.RateLimitConditionMatchingStrategy;
 import com.netflix.zuul.ZuulFilter;
 import com.netflix.zuul.context.RequestContext;
-
 import io.github.bucket4j.ConsumptionProbe;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+
+import javax.servlet.http.HttpServletRequest;
 
 /**
  * {@link ZuulFilter} to configure Bucket4j on each request.
@@ -43,9 +41,9 @@ public class ZuulRateLimitFilter extends ZuulFilter {
 					context.setResponseBody(filterConfig.getHttpResponseBody());
 					context.setSendZuulResponse(false);
 				}
-			}
-			if(filterConfig.getStrategy().equals(RateLimitConditionMatchingStrategy.FIRST)) {
-				break;
+				if(filterConfig.getStrategy().equals(RateLimitConditionMatchingStrategy.FIRST)) {
+					break;
+				}
 			}
 		};
 

--- a/bucket4j-spring-boot-starter/src/test/groovy/com/giffing/bucket4j/spring/boot/starter/zuul/ZuulRateLimitFilterSpec.groovy
+++ b/bucket4j-spring-boot-starter/src/test/groovy/com/giffing/bucket4j/spring/boot/starter/zuul/ZuulRateLimitFilterSpec.groovy
@@ -1,0 +1,110 @@
+package com.giffing.bucket4j.spring.boot.starter.zuul
+
+import com.giffing.bucket4j.spring.boot.starter.context.FilterConfiguration
+import com.giffing.bucket4j.spring.boot.starter.context.RateLimitCheck
+import com.giffing.bucket4j.spring.boot.starter.context.RateLimitConditionMatchingStrategy
+import com.netflix.zuul.context.RequestContext
+import io.github.bucket4j.ConsumptionProbe
+import org.springframework.mock.web.MockHttpServletRequest
+import spock.lang.Specification
+
+import static javax.ws.rs.HttpMethod.GET
+
+class ZuulRateLimitFilterSpec extends Specification {
+
+    ZuulRateLimitFilter filter
+    FilterConfiguration configuration
+    RateLimitCheck rateLimitCheck1
+    RateLimitCheck rateLimitCheck2
+    RateLimitCheck rateLimitCheck3
+
+    def "setup"() {
+        rateLimitCheck1 = Mock(RateLimitCheck)
+        rateLimitCheck2 = Mock(RateLimitCheck)
+        rateLimitCheck3 = Mock(RateLimitCheck)
+
+        configuration = new FilterConfiguration(url: '/url', rateLimitChecks: [rateLimitCheck1, rateLimitCheck2, rateLimitCheck3])
+        filter = new ZuulRateLimitFilter(configuration)
+    }
+
+    def "Should execute all checks when using RateLimitConditionMatchingStrategy.ALL"() {
+        given: "a valid RequestContext and RateLimitConditionMatchingStrategy.ALL"
+
+            MockHttpServletRequest request = new MockHttpServletRequest(GET, '/url')
+            def context = new RequestContext(request: request)
+            RequestContext.testSetCurrentContext(context)
+
+            configuration.strategy = RateLimitConditionMatchingStrategy.ALL
+
+        when: "executing the rate limit filter"
+            filter.run()
+
+        then: "all rate limit checks are performed"
+            1 * rateLimitCheck1.rateLimit(_) >> ConsumptionProbe.consumed(1)
+            1 * rateLimitCheck2.rateLimit(_) >> ConsumptionProbe.consumed(1)
+            1 * rateLimitCheck3.rateLimit(_) >> ConsumptionProbe.consumed(1)
+    }
+
+    def "Should execute all checks when using RateLimitConditionMatchingStrategy.ALL, even if a rate limit check is skipped"() {
+        given: "a valid RequestContext and RateLimitConditionMatchingStrategy.ALL"
+
+            MockHttpServletRequest request = new MockHttpServletRequest(GET, '/url')
+            def context = new RequestContext(request: request)
+            RequestContext.testSetCurrentContext(context)
+
+            configuration.strategy = RateLimitConditionMatchingStrategy.ALL
+
+        when: "executing the rate limit filter"
+            filter.run()
+
+        then: "all rate limit checks are performed"
+            1 * rateLimitCheck1.rateLimit(_) >> null
+            1 * rateLimitCheck2.rateLimit(_) >> ConsumptionProbe.consumed(1)
+            1 * rateLimitCheck3.rateLimit(_) >> ConsumptionProbe.consumed(1)
+    }
+
+    def "Should only execute first checks when using RateLimitConditionMatchingStrategy.FIRST"() {
+        given: "a valid RequestContext and RateLimitConditionMatchingStrategy.ALL"
+
+            MockHttpServletRequest request = new MockHttpServletRequest(GET, '/url')
+            def context = new RequestContext(request: request)
+            RequestContext.testSetCurrentContext(context)
+
+            configuration.strategy = RateLimitConditionMatchingStrategy.FIRST
+
+        when: "executing the rate limit filter"
+            filter.run()
+
+        then: "all rate limit checks are performed"
+            1 * rateLimitCheck1.rateLimit(_) >> ConsumptionProbe.consumed(1)
+            0 * rateLimitCheck2.rateLimit(_) >> ConsumptionProbe.consumed(1)
+            0 * rateLimitCheck3.rateLimit(_) >> ConsumptionProbe.consumed(1)
+    }
+
+    def "Should execute checks until one is not skipped when using RateLimitConditionMatchingStrategy.FIRST"() {
+        given: "a valid RequestContext and RateLimitConditionMatchingStrategy.ALL"
+
+            MockHttpServletRequest request = new MockHttpServletRequest(GET, '/url')
+            def context = new RequestContext(request: request)
+            RequestContext.testSetCurrentContext(context)
+
+            configuration.strategy = RateLimitConditionMatchingStrategy.FIRST
+
+        when: "executing the rate limit filter"
+            filter.run()
+
+        then: "all rate limit checks are performed"
+            1 * rateLimitCheck1.rateLimit(_) >> null
+            1 * rateLimitCheck2.rateLimit(_) >> ConsumptionProbe.consumed(1)
+            0 * rateLimitCheck3.rateLimit(_)
+    }
+
+    private RateLimitCheck mockRateLimitCheck() {
+        def limitCheck = Mock(RateLimitCheck)
+        limitCheck.rateLimit(_) >> {
+            ConsumptionProbe.consumed(1)
+        }
+        limitCheck
+    }
+
+}

--- a/bucket4j-spring-boot-starter/src/test/groovy/com/giffing/bucket4j/spring/boot/starter/zuul/ZuulRateLimitFilterSpec.groovy
+++ b/bucket4j-spring-boot-starter/src/test/groovy/com/giffing/bucket4j/spring/boot/starter/zuul/ZuulRateLimitFilterSpec.groovy
@@ -75,7 +75,7 @@ class ZuulRateLimitFilterSpec extends Specification {
         when: "executing the rate limit filter"
             filter.run()
 
-        then: "all rate limit checks are performed"
+        then: "only the first matching rate limit check is performed"
             1 * rateLimitCheck1.rateLimit(_) >> ConsumptionProbe.consumed(1)
             0 * rateLimitCheck2.rateLimit(_) >> ConsumptionProbe.consumed(1)
             0 * rateLimitCheck3.rateLimit(_) >> ConsumptionProbe.consumed(1)
@@ -93,18 +93,9 @@ class ZuulRateLimitFilterSpec extends Specification {
         when: "executing the rate limit filter"
             filter.run()
 
-        then: "all rate limit checks are performed"
+        then: "only one non-skipped rate limit check is performed"
             1 * rateLimitCheck1.rateLimit(_) >> null
             1 * rateLimitCheck2.rateLimit(_) >> ConsumptionProbe.consumed(1)
             0 * rateLimitCheck3.rateLimit(_)
     }
-
-    private RateLimitCheck mockRateLimitCheck() {
-        def limitCheck = Mock(RateLimitCheck)
-        limitCheck.rateLimit(_) >> {
-            ConsumptionProbe.consumed(1)
-        }
-        limitCheck
-    }
-
 }


### PR DESCRIPTION
Resolves #15 .

Updating ZuulRateLimitFilter to behave the same as ServletRateLimitFilter.

ZuulRateLimitFilter only executed first RateLimitCheck, even if it was skipped due to executeCondition or skipCondition configuration

This change allows configuring rates such as the below. 

```
bucket4j:
  enabled: true
  filters:
  - url: /url
    filter-method: zuul
    filterOrder: 0
    rate-limits:
    - bandwidths:
      - capacity: 2
        time: 1
        unit: minutes
      executeCondition: getMethod() == 'POST'
  - url: /url
    filter-method: zuul
    filterOrder: 1
    rate-limits:
    - bandwidths:
      - capacity: 5
        time: 1
        unit: minutes
  - url: /*
    filter-method: zuul
    filterOrder: 2
    rate-limits:
    - bandwidths:
      - capacity: 8
        time: 1
        unit: minutes
```

For example, prior to this change, a `GET /url` would not be filtered at all. The first rate limit would be skipped due to the `executeCondition`, and then no further limits would be checked at all.

Added a test case to validate the change.