### PR TITLE
Apply InfinispanBucket4jCacheConfiguration with example webflux

### DIFF
--- a/bucket4j-spring-boot-starter/src/main/java/com/giffing/bucket4j/spring/boot/starter/config/cache/Bucket4jCacheConfiguration.java
+++ b/bucket4j-spring-boot-starter/src/main/java/com/giffing/bucket4j/spring/boot/starter/config/cache/Bucket4jCacheConfiguration.java
@@ -1,5 +1,6 @@
 package com.giffing.bucket4j.spring.boot.starter.config.cache;
 
+import com.giffing.bucket4j.spring.boot.starter.config.cache.infinispan.InfinispanBucket4jCacheConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.cache.CacheAutoConfiguration;
 import org.springframework.context.annotation.Configuration;
@@ -19,6 +20,7 @@ import com.giffing.bucket4j.spring.boot.starter.config.cache.redis.springdata.Re
 @Import(value = {
         JCacheBucket4jConfiguration.class,
         InfinispanJCacheBucket4jConfiguration.class,
+        InfinispanBucket4jCacheConfiguration.class,
         HazelcastReactiveBucket4jCacheConfiguration.class,
         HazelcastSpringBucket4jCacheConfiguration.class,
         JedisBucket4jConfiguration.class,

--- a/examples/webflux-infinispan/.gitignore
+++ b/examples/webflux-infinispan/.gitignore
@@ -1,0 +1,9 @@
+/target/
+/.settings/
+.classpath
+.project
+.idea/
+*.iml
+.factorypath
+.apt_generated
+.springBeans

--- a/examples/webflux-infinispan/pom.xml
+++ b/examples/webflux-infinispan/pom.xml
@@ -1,0 +1,81 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>com.giffing.bucket4j.spring.boot.starter</groupId>
+		<artifactId>bucket4j-spring-boot-starter-parent</artifactId>
+		<version>${revision}</version>
+		<relativePath>../..</relativePath>
+	</parent>
+	<artifactId>bucket4j-spring-boot-starter-example-webflux-infinispan</artifactId>
+
+	<properties>
+		<maven.deploy.skip>true</maven.deploy.skip>
+	</properties>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-webflux</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-cache</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-validation</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-actuator</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>com.giffing.bucket4j.spring.boot.starter</groupId>
+			<artifactId>bucket4j-spring-boot-starter</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>javax.cache</groupId>
+			<artifactId>cache-api</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>com.bucket4j</groupId>
+			<artifactId>bucket4j_jdk8-infinispan</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.infinispan</groupId>
+			<artifactId>infinispan-spring-boot-starter-embedded</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.springframework.boot</groupId>
+				<artifactId>spring-boot-maven-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>generate build info</id>
+						<goals>
+							<goal>build-info</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-deploy-plugin</artifactId>
+				<configuration>
+					<skip>true</skip>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+
+</project>

--- a/examples/webflux-infinispan/src/main/java/com/giffing/bucket4j/spring/boot/starter/examples/webflux/DebugMetricHandler.java
+++ b/examples/webflux-infinispan/src/main/java/com/giffing/bucket4j/spring/boot/starter/examples/webflux/DebugMetricHandler.java
@@ -1,0 +1,27 @@
+package com.giffing.bucket4j.spring.boot.starter.examples.webflux;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Component;
+
+import com.giffing.bucket4j.spring.boot.starter.context.metrics.MetricHandler;
+import com.giffing.bucket4j.spring.boot.starter.context.metrics.MetricTagResult;
+import com.giffing.bucket4j.spring.boot.starter.context.metrics.MetricType;
+
+@Component
+public class DebugMetricHandler implements MetricHandler {
+
+	@Override
+	public void handle(MetricType type, String name, long tokens, List<MetricTagResult> tags) {
+		System.out.println(String.format("type: %s; name: %s; tags: %s",
+				type,
+				name,
+				tags
+					.stream()
+					.map(mtr -> mtr.getKey() + ":" + mtr.getValue())
+					.collect(Collectors.joining(","))));
+		
+	}
+
+}

--- a/examples/webflux-infinispan/src/main/java/com/giffing/bucket4j/spring/boot/starter/examples/webflux/MyController.java
+++ b/examples/webflux-infinispan/src/main/java/com/giffing/bucket4j/spring/boot/starter/examples/webflux/MyController.java
@@ -1,0 +1,32 @@
+package com.giffing.bucket4j.spring.boot.starter.examples.webflux;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import reactor.core.publisher.Mono;
+
+@RestController
+@RequestMapping
+public class MyController {
+
+	@GetMapping("/hello")
+    public Mono<String> hello(
+        @RequestParam(defaultValue = "World") String name) {
+        return Mono.just("Hello")
+            .flatMap(s -> Mono
+                .just(s + ", " + name + "!\n")
+            );
+    }
+	
+	@GetMapping("/world")
+    public Mono<String> world(
+        @RequestParam(defaultValue = "World") String name) {
+        return Mono.just("Hello")
+            .flatMap(s -> Mono
+                .just(s + ", " + name + "!\n")
+            );
+    }
+	
+}

--- a/examples/webflux-infinispan/src/main/java/com/giffing/bucket4j/spring/boot/starter/examples/webflux/WebfluxInfinispanApplication.java
+++ b/examples/webflux-infinispan/src/main/java/com/giffing/bucket4j/spring/boot/starter/examples/webflux/WebfluxInfinispanApplication.java
@@ -1,0 +1,15 @@
+package com.giffing.bucket4j.spring.boot.starter.examples.webflux;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cache.annotation.EnableCaching;
+
+@SpringBootApplication
+@EnableCaching
+public class WebfluxInfinispanApplication {
+
+	public static void main(String[] args) {
+		SpringApplication.run(WebfluxInfinispanApplication.class, args);
+	}
+	
+}

--- a/examples/webflux-infinispan/src/main/resources/application.yml
+++ b/examples/webflux-infinispan/src/main/resources/application.yml
@@ -1,0 +1,31 @@
+logging:
+  level:
+    com.giffing.bucket4j.spring.boot.starter: debug
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: "*"
+spring:
+  cache:
+    type: infinispan
+infinispan:
+  embedded:
+    config-xml: infinispan.xml
+bucket4j:
+  enabled: true
+  filters:
+  - cache-name: buckets
+    filter-method: webflux
+    url: .*
+    http-content-type: application/json;charset=UTF-8
+    http-response-body: '{ "name": "hello"}'
+    http-response-headers:
+      HELLO: WORLD
+    filter-order: 1
+    rate-limits:
+    - bandwidths:
+      - capacity: 5
+        time: 10
+        unit: seconds

--- a/examples/webflux-infinispan/src/main/resources/infinispan.xml
+++ b/examples/webflux-infinispan/src/main/resources/infinispan.xml
@@ -1,0 +1,10 @@
+<infinispan>
+    <cache-container name="default" statistics="true">
+        <local-cache name="buckets" statistics="true">
+            <memory max-count="1000000"/>
+        </local-cache>
+        <local-cache name="buckets_test" statistics="true">
+            <memory max-count="1000000"/>
+        </local-cache>
+    </cache-container>
+</infinispan>

--- a/examples/webflux-infinispan/src/test/java/com/giffing/bucket4j/spring/boot/starter/examples/webflux/WebfluxInfinispanRateLimitTest.java
+++ b/examples/webflux-infinispan/src/test/java/com/giffing/bucket4j/spring/boot/starter/examples/webflux/WebfluxInfinispanRateLimitTest.java
@@ -1,0 +1,78 @@
+package com.giffing.bucket4j.spring.boot.starter.examples.webflux;
+
+import java.util.Collections;
+import java.util.stream.IntStream;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.ApplicationContext;
+import org.springframework.http.HttpStatus;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.reactive.server.WebTestClient;
+
+@SpringBootTest
+@ActiveProfiles("webflux-infinispan") // Like this
+class WebfluxInfinispanRateLimitTest {
+
+	@Autowired
+    ApplicationContext context;
+
+    WebTestClient rest;
+
+    @BeforeEach
+    public void setup() {
+        this.rest = WebTestClient
+            .bindToApplicationContext(this.context)
+            .configureClient()
+            .build();
+    }
+
+	@Test
+	void helloTest() throws Exception {
+		String url = "/hello";
+		IntStream.rangeClosed(1, 5)
+			.boxed()
+			.sorted(Collections.reverseOrder())
+			.forEach(counter -> {
+				successfulWebRequest(url, counter - 1);
+			});
+		
+			blockedWebRequestDueToRateLimit(url);
+		}
+
+	
+	@Test
+	void worldTest() throws Exception {
+		String url = "/world";
+		IntStream.rangeClosed(1, 10)
+			.boxed()
+			.sorted(Collections.reverseOrder())
+			.forEach(counter -> {
+				System.out.println(counter);
+				successfulWebRequest(url, counter - 1);
+			});
+		
+			blockedWebRequestDueToRateLimit(url);
+		}
+	
+	private void successfulWebRequest(String url, Integer remainingTries) {
+		rest
+			.get()
+			.uri(url)
+			.exchange()
+			.expectStatus().isOk()
+			.expectHeader().valueEquals("X-Rate-Limit-Remaining", String.valueOf(remainingTries));	
+	}	
+
+	private void blockedWebRequestDueToRateLimit(String url) throws Exception {
+		rest
+		.get()
+		.uri(url)
+		.exchange()
+		.expectStatus().isEqualTo(HttpStatus.TOO_MANY_REQUESTS)
+		.expectBody().jsonPath("error", "Too many requests!");
+	}
+
+}

--- a/examples/webflux-infinispan/src/test/resources/application-webflux-infinispan.yml
+++ b/examples/webflux-infinispan/src/test/resources/application-webflux-infinispan.yml
@@ -1,0 +1,25 @@
+spring:
+  cache:
+    type: infinispan
+infinispan:
+  embedded:
+    config-xml: infinispan.xml
+bucket4j:
+  enabled: true
+  filters:
+  - cache-name: buckets_test
+    filter-method: webflux
+    url: ^(/hello).*
+    rate-limits:
+    - bandwidths:
+      - capacity: 5
+        time: 10
+        unit: seconds
+  - cache-name: buckets_test
+    filter-method: webflux
+    url: ^(/world).*
+    rate-limits:
+    - bandwidths:
+      - capacity: 10
+        time: 10
+        unit: seconds

--- a/pom.xml
+++ b/pom.xml
@@ -23,6 +23,7 @@
 		<module>examples/hazelcast</module>
 		<module>examples/webflux</module>
 		<module>examples/gateway</module>
+		<module>examples/webflux-infinispan</module>
 	</modules>
 	<url>https://github.com/MarcGiffing/bucket4j-spring-boot-starter</url>
 	<licenses>


### PR DESCRIPTION
Infinispan combined with webflux gives a fairly self-contained and customizable cache. The PR contains the use of the InfinispanBucket4jCacheConfiguration configuration and an example using the 'embeded' format for reactive applications