### PR TITLE
Fix async filter matching strategy

### DIFF
--- a/bucket4j-spring-boot-starter/src/test/java/com/giffing/bucket4j/spring/boot/starter/webflux/WebfluxRateLimitFilterTest.java
+++ b/bucket4j-spring-boot-starter/src/test/java/com/giffing/bucket4j/spring/boot/starter/webflux/WebfluxRateLimitFilterTest.java
@@ -38,50 +38,50 @@ class WebfluxRateLimitFilterTest {
 
 	private WebfluxWebFilter filter;
 	private FilterConfiguration<ServerHttpRequest> configuration;
-	private RateLimitCheck rateLimitCheck1;
-	private RateLimitCheck rateLimitCheck2;
-	private RateLimitCheck rateLimitCheck3;
+	private RateLimitCheck<ServerHttpRequest> rateLimitCheck1;
+	private RateLimitCheck<ServerHttpRequest> rateLimitCheck2;
+	private RateLimitCheck<ServerHttpRequest> rateLimitCheck3;
 
 	private ServerWebExchange exchange;
 	private WebFilterChain chain;
-	
-	
-	private ServerHttpResponse serverHttpResponse;
-	
-	@BeforeEach
-    public void setup() throws URISyntaxException {
-    	rateLimitCheck1 = mock(RateLimitCheck.class);
-        rateLimitCheck2 = mock(RateLimitCheck.class);
-        rateLimitCheck3 = mock(RateLimitCheck.class);
 
-        exchange = Mockito.mock(ServerWebExchange.class);
-        
-        ServerHttpRequest serverHttpRequest = Mockito.mock(ServerHttpRequest.class);
-        URI uri = new URI("url");
-        when(serverHttpRequest.getURI()).thenReturn(uri);
+
+	private ServerHttpResponse serverHttpResponse;
+
+	@BeforeEach
+	public void setup() throws URISyntaxException {
+		rateLimitCheck1 = mock(RateLimitCheck.class);
+		rateLimitCheck2 = mock(RateLimitCheck.class);
+		rateLimitCheck3 = mock(RateLimitCheck.class);
+
+		exchange = Mockito.mock(ServerWebExchange.class);
+
+		ServerHttpRequest serverHttpRequest = Mockito.mock(ServerHttpRequest.class);
+		URI uri = new URI("url");
+		when(serverHttpRequest.getURI()).thenReturn(uri);
 		when(exchange.getRequest()).thenReturn(serverHttpRequest);
-		
+
 		serverHttpResponse = Mockito.mock(ServerHttpResponse.class);
-        when(exchange.getResponse()).thenReturn(serverHttpResponse);
-        
+		when(exchange.getResponse()).thenReturn(serverHttpResponse);
+
 		chain = Mockito.mock(WebFilterChain.class);
 		when(chain.filter(exchange)).thenReturn(Mono.empty());
-        
-        configuration = new FilterConfiguration<>();
-        configuration.setRateLimitChecks(Arrays.asList(rateLimitCheck1, rateLimitCheck2, rateLimitCheck3));
-        configuration.setUrl(".*");
-        filter = new WebfluxWebFilter(configuration);
-    }
+
+		configuration = new FilterConfiguration<>();
+		configuration.setRateLimitChecks(Arrays.asList(rateLimitCheck1, rateLimitCheck2, rateLimitCheck3));
+		configuration.setUrl(".*");
+		filter = new WebfluxWebFilter(configuration);
+	}
 
 	@Test void should_throw_rate_limit_exception_with_no_remaining_tokens() {
-		
+
 		configuration.setStrategy(RateLimitConditionMatchingStrategy.FIRST);
 
-        rateLimitConfig(0L, rateLimitCheck1);
-        HttpHeaders httpHeaders = Mockito.mock(HttpHeaders.class);
-        when(serverHttpResponse.getHeaders()).thenReturn(httpHeaders);
-        
-        AtomicBoolean hasRateLimitError = new AtomicBoolean(false);
+		rateLimitConfig(0L, rateLimitCheck1);
+		HttpHeaders httpHeaders = Mockito.mock(HttpHeaders.class);
+		when(serverHttpResponse.getHeaders()).thenReturn(httpHeaders);
+
+		AtomicBoolean hasRateLimitError = new AtomicBoolean(false);
 		Mono<Void> result = filter.filter(exchange, chain)
 				.onErrorResume(ReactiveRateLimitException.class, (e) -> {
 					hasRateLimitError.set(true);
@@ -90,63 +90,63 @@ class WebfluxRateLimitFilterTest {
 		result.subscribe();
 		Assertions.assertTrue(hasRateLimitError.get());
 	}
-	
+
 	@Test
 	void should_execute_all_checks_when_using_RateLimitConditionMatchingStrategy_All() throws URISyntaxException {
-        
-        configuration.setStrategy(RateLimitConditionMatchingStrategy.ALL);
 
-        rateLimitConfig(30L, rateLimitCheck1);
-        rateLimitConfig(0L, rateLimitCheck2);
-        rateLimitConfig(0L, rateLimitCheck3);
+		configuration.setStrategy(RateLimitConditionMatchingStrategy.ALL);
 
-        HttpHeaders httpHeaders = Mockito.mock(HttpHeaders.class);
-        when(serverHttpResponse.getHeaders()).thenReturn(httpHeaders);
-        
-        Assertions.assertThrows(ReactiveRateLimitException.class, () -> {
-        	Mono<Void> result = filter.filter(exchange, chain);
-    		result.block();	
-        });
-		
+		rateLimitConfig(30L, rateLimitCheck1);
+		rateLimitConfig(0L, rateLimitCheck2);
+		rateLimitConfig(0L, rateLimitCheck3);
+
+		HttpHeaders httpHeaders = Mockito.mock(HttpHeaders.class);
+		when(serverHttpResponse.getHeaders()).thenReturn(httpHeaders);
+
+		Assertions.assertThrows(ReactiveRateLimitException.class, () -> {
+			Mono<Void> result = filter.filter(exchange, chain);
+			result.block();
+		});
+
 		verify(rateLimitCheck1).rateLimit(any());
-        verify(rateLimitCheck2).rateLimit(any());
-        verify(rateLimitCheck3).rateLimit(any());
+		verify(rateLimitCheck2).rateLimit(any());
+		verify(rateLimitCheck3).rateLimit(any());
 	}
 
 	@Test
 	void should_execute_only_one_check_when_using_RateLimitConditionMatchingStrategy_FIRST() {
-        
-        configuration.setStrategy(RateLimitConditionMatchingStrategy.FIRST);
 
-        rateLimitConfig(30L, rateLimitCheck1);
-        rateLimitConfig(0L, rateLimitCheck2);
-        rateLimitConfig(10L, rateLimitCheck3);
-        
-        HttpHeaders httpHeaders = Mockito.mock(HttpHeaders.class);
-        when(serverHttpResponse.getHeaders()).thenReturn(httpHeaders);
-        
-    	Mono<Void> result = filter.filter(exchange, chain);
+		configuration.setStrategy(RateLimitConditionMatchingStrategy.FIRST);
+
+		rateLimitConfig(30L, rateLimitCheck1);
+		rateLimitConfig(0L, rateLimitCheck2);
+		rateLimitConfig(10L, rateLimitCheck3);
+
+		HttpHeaders httpHeaders = Mockito.mock(HttpHeaders.class);
+		when(serverHttpResponse.getHeaders()).thenReturn(httpHeaders);
+
+		Mono<Void> result = filter.filter(exchange, chain);
 		result.block();
-        
-		final ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
-        verify(httpHeaders, times(1)).set(any(), captor.capture());
 
-        List<String> values = captor.getAllValues();
-        Assertions.assertEquals("30", values.stream().findFirst().get());
-        
-        verify(rateLimitCheck1).rateLimit(any());
-        verify(rateLimitCheck2).rateLimit(any());
-        verify(rateLimitCheck3).rateLimit(any());
+		final ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
+		verify(httpHeaders, times(1)).set(any(), captor.capture());
+
+		List<String> values = captor.getAllValues();
+		Assertions.assertEquals("30", values.stream().findFirst().get());
+
+		verify(rateLimitCheck1, times(1)).rateLimit(any());
+		verify(rateLimitCheck2, times(0)).rateLimit(any());
+		verify(rateLimitCheck3, times(0)).rateLimit(any());
 	}
 
-	private void rateLimitConfig(Long remainingTokens, RateLimitCheck rateLimitCheck) {
+	private void rateLimitConfig(Long remainingTokens, RateLimitCheck<ServerHttpRequest> rateLimitCheck) {
 		ConsumptionProbeHolder consumptionHolder = Mockito.mock(ConsumptionProbeHolder.class);
-        ConsumptionProbe probe = Mockito.mock(ConsumptionProbe.class);
-		when(probe.isConsumed()).thenReturn(remainingTokens > 0 ? true : false);
+		ConsumptionProbe probe = Mockito.mock(ConsumptionProbe.class);
+		when(probe.isConsumed()).thenReturn(remainingTokens > 0);
 		when(probe.getRemainingTokens()).thenReturn(remainingTokens);
 		when(consumptionHolder.getConsumptionProbeCompletableFuture())
-			.thenReturn(CompletableFuture.completedFuture(probe));
-        when(rateLimitCheck.rateLimit(any())).thenReturn(consumptionHolder);
+				.thenReturn(CompletableFuture.completedFuture(probe));
+		when(rateLimitCheck.rateLimit(any())).thenReturn(consumptionHolder);
 	}
-	
+
 }

--- a/examples/gateway/src/main/resources/application.yml
+++ b/examples/gateway/src/main/resources/application.yml
@@ -6,16 +6,30 @@ management:
     web:
       exposure:
         include: "*"
-bucket4j:  default-tags:  - expression: "1"     key: xx  filters:
+bucket4j:
+  default-tags:
+  - expression: "1" 
+    key: xx
+  filters:
   - metrics:
       types:
       - consumed-counter
-      - rejected-counter      tags:      - key: xx        expression: "2"    cache-name: buckets
+      - rejected-counter
+      tags:
+      - key: xx
+        expression: "2"
+    cache-name: buckets
     filter-method: gateway
     url: .*
     filter-order: -100000
     rate-limits:
-    - bandwidths:
-      - capacity: 5
-        time: 10
-        unit: seconds        refill-speed: interval
+      - bandwidths:
+          - capacity: 5
+            time: 10
+            unit: seconds
+            refill-speed: interval
+      - bandwidths:
+          - capacity: 5
+            time: 10
+            unit: seconds
+            refill-speed: interval


### PR DESCRIPTION
The RateLimitConditionMatchingStrategy.FIRST check was done after all the ratelimit checks are executed. This caused tokens to be consumed from all ratelimitcheck buckets, while only the first ratelimitcheck should have been consumed. This should now be fixed.