### PR TITLE
Resolve bug mentioned in Issue #222

### DIFF
--- a/bucket4j-spring-boot-starter/src/main/java/com/giffing/bucket4j/spring/boot/starter/config/cache/hazelcast/HazelcastReactiveBucket4jCacheConfiguration.java
+++ b/bucket4j-spring-boot-starter/src/main/java/com/giffing/bucket4j/spring/boot/starter/config/cache/hazelcast/HazelcastReactiveBucket4jCacheConfiguration.java
@@ -40,14 +40,14 @@ public class HazelcastReactiveBucket4jCacheConfiguration {
 
 	@Bean
 	@ConditionalOnMissingBean(CacheManager.class)
-	@ConditionalOnProperty(prefix = Bucket4JBootProperties.PROPERTY_PREFIX, name = "filter-config-caching-enabled", havingValue = "true", matchIfMissing = true)
+	@ConditionalOnProperty(prefix = Bucket4JBootProperties.PROPERTY_PREFIX, name = "filter-config-caching-enabled", havingValue = "true")
 	public CacheManager<String, Bucket4JConfiguration> configCacheManager() {
 		IMap<String, Bucket4JConfiguration> map = hazelcastInstance.getMap(configCacheName);
 		return new HazelcastCacheManager<>(map);
 	}
 
 	@Bean
-	@ConditionalOnProperty(prefix = Bucket4JBootProperties.PROPERTY_PREFIX, name = "filter-config-caching-enabled", havingValue = "true", matchIfMissing = true)
+	@ConditionalOnProperty(prefix = Bucket4JBootProperties.PROPERTY_PREFIX, name = "filter-config-caching-enabled", havingValue = "true")
 	public HazelcastCacheListener<String, Bucket4JConfiguration> configCacheListener() {
 		IMap<String, Bucket4JConfiguration> map = hazelcastInstance.getMap(configCacheName);
 		return new HazelcastCacheListener<>(map);

--- a/bucket4j-spring-boot-starter/src/main/java/com/giffing/bucket4j/spring/boot/starter/config/cache/hazelcast/HazelcastSpringBucket4jCacheConfiguration.java
+++ b/bucket4j-spring-boot-starter/src/main/java/com/giffing/bucket4j/spring/boot/starter/config/cache/hazelcast/HazelcastSpringBucket4jCacheConfiguration.java
@@ -41,14 +41,14 @@ public class HazelcastSpringBucket4jCacheConfiguration {
 
 	@Bean
 	@ConditionalOnMissingBean(CacheManager.class)
-	@ConditionalOnProperty(prefix = Bucket4JBootProperties.PROPERTY_PREFIX, name = "filter-config-caching-enabled", havingValue = "true", matchIfMissing = true)
+	@ConditionalOnProperty(prefix = Bucket4JBootProperties.PROPERTY_PREFIX, name = "filter-config-caching-enabled", havingValue = "true")
 	public CacheManager<String, Bucket4JConfiguration> configCacheManager() {
 		IMap<String, Bucket4JConfiguration> map = hazelcastInstance.getMap(configCacheName);
 		return new com.giffing.bucket4j.spring.boot.starter.config.cache.hazelcast.HazelcastCacheManager<>(map);
 	}
 
 	@Bean
-	@ConditionalOnProperty(prefix = Bucket4JBootProperties.PROPERTY_PREFIX, name = "filter-config-caching-enabled", havingValue = "true", matchIfMissing = true)
+	@ConditionalOnProperty(prefix = Bucket4JBootProperties.PROPERTY_PREFIX, name = "filter-config-caching-enabled", havingValue = "true")
 	public HazelcastCacheListener<String, Bucket4JConfiguration> configCacheListener() {
 		IMap<String, Bucket4JConfiguration> map = hazelcastInstance.getMap(configCacheName);
 		return new HazelcastCacheListener<>(map);

--- a/bucket4j-spring-boot-starter/src/main/java/com/giffing/bucket4j/spring/boot/starter/config/cache/ignite/IgniteBucket4jCacheConfiguration.java
+++ b/bucket4j-spring-boot-starter/src/main/java/com/giffing/bucket4j/spring/boot/starter/config/cache/ignite/IgniteBucket4jCacheConfiguration.java
@@ -32,13 +32,13 @@ public class IgniteBucket4jCacheConfiguration {
 
 	@Bean
 	@ConditionalOnMissingBean(CacheManager.class)
-	@ConditionalOnProperty(prefix = Bucket4JBootProperties.PROPERTY_PREFIX, name = "filter-config-caching-enabled", havingValue = "true", matchIfMissing = true)
+	@ConditionalOnProperty(prefix = Bucket4JBootProperties.PROPERTY_PREFIX, name = "filter-config-caching-enabled", havingValue = "true")
 	public CacheManager<String, Bucket4JConfiguration> configCacheManager() {
 		return new IgniteCacheManager<>(ignite.cache(configCacheName));
 	}
 
 	@Bean
-	@ConditionalOnProperty(prefix = Bucket4JBootProperties.PROPERTY_PREFIX, name = "filter-config-caching-enabled", havingValue = "true", matchIfMissing = true)
+	@ConditionalOnProperty(prefix = Bucket4JBootProperties.PROPERTY_PREFIX, name = "filter-config-caching-enabled", havingValue = "true")
 	public IgniteCacheListener<String, Bucket4JConfiguration> configCacheListener() {
 		return new IgniteCacheListener<>(ignite.cache(configCacheName));
 	}

--- a/bucket4j-spring-boot-starter/src/main/java/com/giffing/bucket4j/spring/boot/starter/config/cache/infinispan/InfinispanBucket4jCacheConfiguration.java
+++ b/bucket4j-spring-boot-starter/src/main/java/com/giffing/bucket4j/spring/boot/starter/config/cache/infinispan/InfinispanBucket4jCacheConfiguration.java
@@ -32,13 +32,13 @@ public class InfinispanBucket4jCacheConfiguration {
 
 	@Bean
 	@ConditionalOnMissingBean(CacheManager.class)
-	@ConditionalOnProperty(prefix = Bucket4JBootProperties.PROPERTY_PREFIX, name = "filter-config-caching-enabled", havingValue = "true", matchIfMissing = true)
+	@ConditionalOnProperty(prefix = Bucket4JBootProperties.PROPERTY_PREFIX, name = "filter-config-caching-enabled", havingValue = "true")
 	public CacheManager<String, Bucket4JConfiguration> configCacheManager() {
 		return new InfinispanCacheManager<>(cacheContainer.getCache(configCacheName));
 	}
 
 	@Bean
-	@ConditionalOnProperty(prefix = Bucket4JBootProperties.PROPERTY_PREFIX, name = "filter-config-caching-enabled", havingValue = "true", matchIfMissing = true)
+	@ConditionalOnProperty(prefix = Bucket4JBootProperties.PROPERTY_PREFIX, name = "filter-config-caching-enabled", havingValue = "true")
 	public InfinispanCacheListener<String, Bucket4JConfiguration> configCacheListener() {
 		return new InfinispanCacheListener<>(cacheContainer.getCache(configCacheName));
 	}

--- a/bucket4j-spring-boot-starter/src/main/java/com/giffing/bucket4j/spring/boot/starter/config/cache/jcache/InfinispanJCacheBucket4jConfiguration.java
+++ b/bucket4j-spring-boot-starter/src/main/java/com/giffing/bucket4j/spring/boot/starter/config/cache/jcache/InfinispanJCacheBucket4jConfiguration.java
@@ -45,13 +45,13 @@ public class InfinispanJCacheBucket4jConfiguration {
 
 	@Bean
 	@ConditionalOnMissingBean(CacheManager.class)
-	@ConditionalOnProperty(prefix = Bucket4JBootProperties.PROPERTY_PREFIX, name = "filter-config-caching-enabled", havingValue = "true", matchIfMissing = true)
+	@ConditionalOnProperty(prefix = Bucket4JBootProperties.PROPERTY_PREFIX, name = "filter-config-caching-enabled", havingValue = "true")
 	public CacheManager<String, Bucket4JConfiguration> configCacheManager() {
 		return new InfinispanCacheManager<>(cacheContainer.getCache(configCacheName));
 	}
 
 	@Bean
-	@ConditionalOnProperty(prefix = Bucket4JBootProperties.PROPERTY_PREFIX, name = "filter-config-caching-enabled", havingValue = "true", matchIfMissing = true)
+	@ConditionalOnProperty(prefix = Bucket4JBootProperties.PROPERTY_PREFIX, name = "filter-config-caching-enabled", havingValue = "true")
 	public InfinispanCacheListener<String, Bucket4JConfiguration> configCacheListener() {
 		return new InfinispanCacheListener<>(cacheContainer.getCache(configCacheName));
 	}

--- a/bucket4j-spring-boot-starter/src/main/java/com/giffing/bucket4j/spring/boot/starter/config/cache/jcache/JCacheBucket4jConfiguration.java
+++ b/bucket4j-spring-boot-starter/src/main/java/com/giffing/bucket4j/spring/boot/starter/config/cache/jcache/JCacheBucket4jConfiguration.java
@@ -36,14 +36,14 @@ public class JCacheBucket4jConfiguration {
 
 	@Bean
 	@ConditionalOnMissingBean(com.giffing.bucket4j.spring.boot.starter.config.cache.CacheManager.class)
-	@ConditionalOnProperty(prefix = Bucket4JBootProperties.PROPERTY_PREFIX, name = "filter-config-caching-enabled", havingValue = "true", matchIfMissing = true)
+	@ConditionalOnProperty(prefix = Bucket4JBootProperties.PROPERTY_PREFIX, name = "filter-config-caching-enabled", havingValue = "true")
 	public com.giffing.bucket4j.spring.boot.starter.config.cache.CacheManager<String, Bucket4JConfiguration> configCacheManager(
 	) {
 		return new com.giffing.bucket4j.spring.boot.starter.config.cache.jcache.JCacheCacheManager<>(cacheManager.getCache(configCacheName));
 	}
 
 	@Bean
-	@ConditionalOnProperty(prefix = Bucket4JBootProperties.PROPERTY_PREFIX, name = "filter-config-caching-enabled", havingValue = "true", matchIfMissing = true)
+	@ConditionalOnProperty(prefix = Bucket4JBootProperties.PROPERTY_PREFIX, name = "filter-config-caching-enabled", havingValue = "true")
 	public JCacheCacheListener<String, Bucket4JConfiguration> configCacheListener() {
 		return new JCacheCacheListener<>(cacheManager.getCache(configCacheName));
 	}

--- a/bucket4j-spring-boot-starter/src/main/java/com/giffing/bucket4j/spring/boot/starter/config/cache/redis/jedis/JedisBucket4jConfiguration.java
+++ b/bucket4j-spring-boot-starter/src/main/java/com/giffing/bucket4j/spring/boot/starter/config/cache/redis/jedis/JedisBucket4jConfiguration.java
@@ -33,13 +33,13 @@ public class JedisBucket4jConfiguration {
 
 	@Bean
 	@ConditionalOnMissingBean(CacheManager.class)
-	@ConditionalOnProperty(prefix = Bucket4JBootProperties.PROPERTY_PREFIX, name = "filter-config-caching-enabled", havingValue = "true", matchIfMissing = true)
+	@ConditionalOnProperty(prefix = Bucket4JBootProperties.PROPERTY_PREFIX, name = "filter-config-caching-enabled", havingValue = "true")
 	public CacheManager<String, Bucket4JConfiguration> configCacheManager() {
 		return new JedisCacheManager<>(jedisPool, configCacheName, Bucket4JConfiguration.class);
 	}
 
 	@Bean
-	@ConditionalOnProperty(prefix = Bucket4JBootProperties.PROPERTY_PREFIX, name = "filter-config-caching-enabled", havingValue = "true", matchIfMissing = true)
+	@ConditionalOnProperty(prefix = Bucket4JBootProperties.PROPERTY_PREFIX, name = "filter-config-caching-enabled", havingValue = "true")
 	public JedisCacheListener<String, Bucket4JConfiguration> configCacheListener() {
 		return new JedisCacheListener<>(jedisPool, configCacheName, String.class, Bucket4JConfiguration.class);
 	}

--- a/bucket4j-spring-boot-starter/src/main/java/com/giffing/bucket4j/spring/boot/starter/config/cache/redis/lettuce/LettuceBucket4jConfiguration.java
+++ b/bucket4j-spring-boot-starter/src/main/java/com/giffing/bucket4j/spring/boot/starter/config/cache/redis/lettuce/LettuceBucket4jConfiguration.java
@@ -32,13 +32,13 @@ public class LettuceBucket4jConfiguration {
 
 	@Bean
 	@ConditionalOnMissingBean(CacheManager.class)
-	@ConditionalOnProperty(prefix = Bucket4JBootProperties.PROPERTY_PREFIX, name = "filter-config-caching-enabled", havingValue = "true", matchIfMissing = true)
+	@ConditionalOnProperty(prefix = Bucket4JBootProperties.PROPERTY_PREFIX, name = "filter-config-caching-enabled", havingValue = "true")
 	public CacheManager<String, Bucket4JConfiguration> configCacheManager() {
 		return new LettuceCacheManager<>(redisClient, configCacheName, Bucket4JConfiguration.class);
 	}
 
 	@Bean
-	@ConditionalOnProperty(prefix = Bucket4JBootProperties.PROPERTY_PREFIX, name = "filter-config-caching-enabled", havingValue = "true", matchIfMissing = true)
+	@ConditionalOnProperty(prefix = Bucket4JBootProperties.PROPERTY_PREFIX, name = "filter-config-caching-enabled", havingValue = "true")
 	public LettuceCacheListener<String, Bucket4JConfiguration> configCacheListener() {
 		return new LettuceCacheListener<>(redisClient, configCacheName, String.class, Bucket4JConfiguration.class);
 	}

--- a/bucket4j-spring-boot-starter/src/main/java/com/giffing/bucket4j/spring/boot/starter/config/cache/redis/redisson/RedissonBucket4jConfiguration.java
+++ b/bucket4j-spring-boot-starter/src/main/java/com/giffing/bucket4j/spring/boot/starter/config/cache/redis/redisson/RedissonBucket4jConfiguration.java
@@ -43,13 +43,13 @@ public class RedissonBucket4jConfiguration {
 
 	@Bean
 	@ConditionalOnMissingBean(CacheManager.class)
-	@ConditionalOnProperty(prefix = Bucket4JBootProperties.PROPERTY_PREFIX, name = "filter-config-caching-enabled", havingValue = "true", matchIfMissing = true)
+	@ConditionalOnProperty(prefix = Bucket4JBootProperties.PROPERTY_PREFIX, name = "filter-config-caching-enabled", havingValue = "true")
 	public CacheManager<String, Bucket4JConfiguration> configCacheManager() {
 		return new RedissonCacheManager<>(this.redissonClient, configCacheName);
 	}
 
 	@Bean
-	@ConditionalOnProperty(prefix = Bucket4JBootProperties.PROPERTY_PREFIX, name = "filter-config-caching-enabled", havingValue = "true", matchIfMissing = true)
+	@ConditionalOnProperty(prefix = Bucket4JBootProperties.PROPERTY_PREFIX, name = "filter-config-caching-enabled", havingValue = "true")
 	public RedissonCacheListener<String, Bucket4JConfiguration> configCacheListener() {
 		return new RedissonCacheListener<>(this.redissonClient, configCacheName);
 	}

--- a/examples/caffeine/src/main/java/com/giffing/bucket4j/spring/boot/starter/examples/caffeine/TestController.java
+++ b/examples/caffeine/src/main/java/com/giffing/bucket4j/spring/boot/starter/examples/caffeine/TestController.java
@@ -5,6 +5,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 
+import jakarta.annotation.Nullable;
 import jakarta.validation.ConstraintViolation;
 import jakarta.validation.Valid;
 import jakarta.validation.Validator;
@@ -26,9 +27,10 @@ import org.springframework.web.util.HtmlUtils;
 public class TestController {
 
 	private final Validator validator;
+
 	private final CacheManager<String, Bucket4JConfiguration> configCacheManager;
 
-	public TestController(Validator validator, CacheManager<String, Bucket4JConfiguration> configCacheManager) {
+	public TestController(Validator validator, @Nullable CacheManager<String, Bucket4JConfiguration> configCacheManager) {
 		this.validator = validator;
 		this.configCacheManager = configCacheManager;
 	}
@@ -60,6 +62,7 @@ public class TestController {
 			@PathVariable String filterId,
 			@RequestBody @Valid Bucket4JConfiguration newConfig,
 			BindingResult bindingResult) {
+		if(configCacheManager == null) return ResponseEntity.status(HttpStatus.FORBIDDEN).body("Dynamic updating is disabled");
 
 		//validate that the path id matches the body
 		if (!newConfig.getId().equals(filterId)) {

--- a/examples/caffeine/src/main/resources/application.yml
+++ b/examples/caffeine/src/main/resources/application.yml
@@ -20,6 +20,7 @@ spring:
 bucket4j:
   enabled: true
   filter-config-caching-enabled: true
+  filter-config-cache-name: filterConfigCache
   filters:
   - id: filter1
     cache-name: buckets

--- a/examples/caffeine/src/test/resources/application-servlet.yml
+++ b/examples/caffeine/src/test/resources/application-servlet.yml
@@ -7,6 +7,8 @@ spring:
       spec: maximumSize=1000000,expireAfterAccess=3600s
 bucket4j:
   enabled: true
+  filter-config-caching-enabled: true
+  filter-config-cache-name: filterConfigCache
   filters:
   - id: filter1
     cache-name: buckets_test

--- a/examples/ehcache/src/main/java/com/giffing/bucket4j/spring/boot/starter/examples/ehcache/controller/TestController.java
+++ b/examples/ehcache/src/main/java/com/giffing/bucket4j/spring/boot/starter/examples/ehcache/controller/TestController.java
@@ -3,10 +3,13 @@ package com.giffing.bucket4j.spring.boot.starter.examples.ehcache.controller;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Optional;
 
 import com.giffing.bucket4j.spring.boot.starter.utils.Bucket4JUtils;
+import jakarta.annotation.Nullable;
 import jakarta.validation.Valid;
 import org.springframework.context.support.DefaultMessageSourceResolvable;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
@@ -29,7 +32,7 @@ public class TestController {
 
 	private final CacheManager<String, Bucket4JConfiguration> configCacheManager;
 
-	public TestController(CacheManager<String, Bucket4JConfiguration> configCacheManager) {
+	public TestController(@Nullable CacheManager<String, Bucket4JConfiguration> configCacheManager) {
 		this.configCacheManager = configCacheManager;
 	}
 
@@ -93,6 +96,7 @@ public class TestController {
 		@PathVariable String filterId,
 		@RequestBody @Valid Bucket4JConfiguration newConfig,
 		BindingResult bindingResult) {
+		if(configCacheManager == null) return ResponseEntity.status(HttpStatus.FORBIDDEN).body("Dynamic updating is disabled");
 
 		//validate that the path id matches the body
 		if (!newConfig.getId().equals(filterId)) {

--- a/examples/gateway/src/main/java/com/giffing/bucket4j/spring/boot/starter/examples/gateway/TestController.java
+++ b/examples/gateway/src/main/java/com/giffing/bucket4j/spring/boot/starter/examples/gateway/TestController.java
@@ -1,11 +1,13 @@
 package com.giffing.bucket4j.spring.boot.starter.examples.gateway;
 
 import com.giffing.bucket4j.spring.boot.starter.utils.Bucket4JUtils;
+import jakarta.annotation.Nullable;
 import jakarta.validation.ConstraintViolation;
 import jakarta.validation.Valid;
 import jakarta.validation.Validator;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.support.DefaultMessageSourceResolvable;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.*;
@@ -14,6 +16,7 @@ import com.giffing.bucket4j.spring.boot.starter.config.cache.CacheManager;
 import com.giffing.bucket4j.spring.boot.starter.context.properties.Bucket4JConfiguration;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 
 @RestController
@@ -25,7 +28,7 @@ public class TestController {
 
 	private final CacheManager<String, Bucket4JConfiguration> configCacheManager;
 
-	public TestController(CacheManager<String, Bucket4JConfiguration> configCacheManager){
+	public TestController(@Nullable CacheManager<String, Bucket4JConfiguration> configCacheManager){
 		this.configCacheManager = configCacheManager;
 	}
 
@@ -39,6 +42,7 @@ public class TestController {
 	public ResponseEntity<?> updateConfig(
 		@PathVariable String filterId,
 		@RequestBody Bucket4JConfiguration newConfig) {
+		if(configCacheManager == null) return ResponseEntity.status(HttpStatus.FORBIDDEN).body("Dynamic updating is disabled");
 
 		//validate that the path id matches the body
 		if (!newConfig.getId().equals(filterId)) {

--- a/examples/hazelcast/src/main/java/com/giffing/bucket4j/spring/boot/starter/examples/hazelcast/TestController.java
+++ b/examples/hazelcast/src/main/java/com/giffing/bucket4j/spring/boot/starter/examples/hazelcast/TestController.java
@@ -1,8 +1,10 @@
 package com.giffing.bucket4j.spring.boot.starter.examples.hazelcast;
 
 import com.giffing.bucket4j.spring.boot.starter.utils.Bucket4JUtils;
+import jakarta.annotation.Nullable;
 import jakarta.validation.Valid;
 import org.springframework.context.support.DefaultMessageSourceResolvable;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.*;
@@ -18,7 +20,7 @@ public class TestController {
 
 	private final CacheManager<String, Bucket4JConfiguration> configCacheManager;
 
-	public TestController(CacheManager<String, Bucket4JConfiguration> configCacheManager) {
+	public TestController(@Nullable CacheManager<String, Bucket4JConfiguration> configCacheManager) {
 		this.configCacheManager = configCacheManager;
 	}
 
@@ -40,6 +42,7 @@ public class TestController {
 		@PathVariable String filterId,
 		@RequestBody @Valid Bucket4JConfiguration newConfig,
 		BindingResult bindingResult) {
+		if(configCacheManager == null) return ResponseEntity.status(HttpStatus.FORBIDDEN).body("Dynamic updating is disabled");
 
 		//validate that the path id matches the body
 		if (!newConfig.getId().equals(filterId)) {

--- a/examples/hazelcast/src/main/resources/application.yml
+++ b/examples/hazelcast/src/main/resources/application.yml
@@ -8,6 +8,7 @@ spring:
 bucket4j:
   enabled: true
   filter-config-caching-enabled: true
+  filter-config-cache-name: filterConfigCache
   filters:
   - id: filter1
     cache-name: buckets

--- a/examples/redis-jedis/src/main/java/com/giffing/bucket4j/spring/boot/starter/TestController.java
+++ b/examples/redis-jedis/src/main/java/com/giffing/bucket4j/spring/boot/starter/TestController.java
@@ -1,8 +1,10 @@
 package com.giffing.bucket4j.spring.boot.starter;
 
 import com.giffing.bucket4j.spring.boot.starter.utils.Bucket4JUtils;
+import jakarta.annotation.Nullable;
 import jakarta.validation.Valid;
 import org.springframework.context.support.DefaultMessageSourceResolvable;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.*;
@@ -17,7 +19,7 @@ public class TestController {
 
 	private final CacheManager<String, Bucket4JConfiguration> configCacheManager;
 
-	public TestController(CacheManager<String,Bucket4JConfiguration> configCacheManager){
+	public TestController(@Nullable CacheManager<String,Bucket4JConfiguration> configCacheManager){
 		this.configCacheManager = configCacheManager;
 	}
 
@@ -44,6 +46,7 @@ public class TestController {
 		@PathVariable String filterId,
 		@RequestBody @Valid Bucket4JConfiguration newConfig,
 		BindingResult bindingResult) {
+		if(configCacheManager == null) return ResponseEntity.status(HttpStatus.FORBIDDEN).body("Dynamic updating is disabled");
 
 		//validate that the path id matches the body
 		if (!newConfig.getId().equals(filterId)) {

--- a/examples/redis-jedis/src/main/resources/application.yml
+++ b/examples/redis-jedis/src/main/resources/application.yml
@@ -13,6 +13,8 @@ management:
 bucket4j:
   enabled: true
   cache-to-use: redis-jedis
+  filter-config-caching-enabled: true
+  filter-config-cache-name: filterConfigCache
   filters:
     - cache-name: buckets_test
       major-version: 2
@@ -35,7 +37,6 @@ bucket4j:
               time: 10
               unit: seconds
               refill-speed: interval
-  filter-config-caching-enabled: true
 
 spring:
   main:

--- a/examples/redis-lettuce/src/main/java/com/giffing/bucket4j/spring/boot/starter/TestController.java
+++ b/examples/redis-lettuce/src/main/java/com/giffing/bucket4j/spring/boot/starter/TestController.java
@@ -3,9 +3,11 @@ package com.giffing.bucket4j.spring.boot.starter;
 import com.giffing.bucket4j.spring.boot.starter.config.cache.CacheManager;
 import com.giffing.bucket4j.spring.boot.starter.context.properties.Bucket4JConfiguration;
 import com.giffing.bucket4j.spring.boot.starter.utils.Bucket4JUtils;
+import jakarta.annotation.Nullable;
 import jakarta.validation.ConstraintViolation;
 import jakarta.validation.Validator;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -20,7 +22,7 @@ public class TestController {
 
 	private final CacheManager<String, Bucket4JConfiguration> configCacheManager;
 
-	public TestController(CacheManager<String,Bucket4JConfiguration> configCacheManager){
+	public TestController(@Nullable CacheManager<String,Bucket4JConfiguration> configCacheManager){
 		this.configCacheManager = configCacheManager;
 	}
 
@@ -45,6 +47,7 @@ public class TestController {
 	public ResponseEntity<?> updateConfig(
 		@PathVariable String filterId,
 		@RequestBody Bucket4JConfiguration newConfig) {
+		if(configCacheManager == null) return ResponseEntity.status(HttpStatus.FORBIDDEN).body("Dynamic updating is disabled");
 
 		//validate that the path id matches the body
 		if (!newConfig.getId().equals(filterId)) {

--- a/examples/redis-lettuce/src/main/resources/application.yml
+++ b/examples/redis-lettuce/src/main/resources/application.yml
@@ -13,6 +13,8 @@ management:
 bucket4j:
   enabled: true
   cache-to-use: redis-lettuce
+  filter-config-caching-enabled: true
+  filter-config-cache-name: filterConfigCache
   filters:
     - cache-name: buckets_test
       id: filter1
@@ -34,7 +36,6 @@ bucket4j:
               time: 10
               unit: seconds
               refill-speed: interval
-  filter-config-caching-enabled: true
 
 spring:
   main:

--- a/examples/redis-redisson/src/main/java/com/giffing/bucket4j/spring/boot/starter/TestController.java
+++ b/examples/redis-redisson/src/main/java/com/giffing/bucket4j/spring/boot/starter/TestController.java
@@ -20,7 +20,7 @@ public class TestController {
 
 	private final CacheManager<String, Bucket4JConfiguration> configCacheManager;
 
-	public TestController(CacheManager<String, Bucket4JConfiguration> configCacheManager){
+	public TestController(@Nullable CacheManager<String, Bucket4JConfiguration> configCacheManager){
 		this.configCacheManager = configCacheManager;
 	}
 
@@ -45,6 +45,7 @@ public class TestController {
 	public ResponseEntity<?> updateConfig(
 		@PathVariable String filterId,
 		@RequestBody Bucket4JConfiguration newConfig) {
+		if(configCacheManager == null) return ResponseEntity.status(HttpStatus.FORBIDDEN).body("Dynamic updating is disabled");
 
 		//validate that the path id matches the body
 		if (!newConfig.getId().equals(filterId)) {

--- a/examples/redis-redisson/src/main/resources/application.yml
+++ b/examples/redis-redisson/src/main/resources/application.yml
@@ -12,6 +12,8 @@ management:
 bucket4j:
   enabled: true
   cache-to-use: redis-redisson
+  filter-config-caching-enabled: true
+  filter-config-cache-name: filterConfigCache
   filters:
     - id: filter1
       major-version: 1
@@ -39,7 +41,6 @@ bucket4j:
               time: 10
               unit: seconds
               refill-speed: interval
-  filter-config-caching-enabled: true
 
 spring:
   main:

--- a/examples/webflux-infinispan/src/main/java/com/giffing/bucket4j/spring/boot/starter/examples/webflux/MyController.java
+++ b/examples/webflux-infinispan/src/main/java/com/giffing/bucket4j/spring/boot/starter/examples/webflux/MyController.java
@@ -3,9 +3,11 @@ package com.giffing.bucket4j.spring.boot.starter.examples.webflux;
 import com.giffing.bucket4j.spring.boot.starter.config.cache.CacheManager;
 import com.giffing.bucket4j.spring.boot.starter.context.properties.Bucket4JConfiguration;
 import com.giffing.bucket4j.spring.boot.starter.utils.Bucket4JUtils;
+import jakarta.annotation.Nullable;
 import jakarta.validation.ConstraintViolation;
 import jakarta.validation.Validator;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import reactor.core.publisher.Mono;
@@ -22,7 +24,7 @@ public class MyController {
 
     private final CacheManager<String, Bucket4JConfiguration> configCacheManager;
 
-    public MyController(CacheManager<String, Bucket4JConfiguration> configCacheManager) {
+    public MyController(@Nullable CacheManager<String, Bucket4JConfiguration> configCacheManager) {
         this.configCacheManager = configCacheManager;
     }
 
@@ -55,6 +57,7 @@ public class MyController {
     public ResponseEntity<?> updateConfig(
         @PathVariable String filterId,
         @RequestBody Bucket4JConfiguration newConfig) {
+        if(configCacheManager == null) return ResponseEntity.status(HttpStatus.FORBIDDEN).body("Dynamic updating is disabled");
 
 		//validate that the path id matches the body
 		if (!newConfig.getId().equals(filterId)) {

--- a/examples/webflux-infinispan/src/main/resources/application.yml
+++ b/examples/webflux-infinispan/src/main/resources/application.yml
@@ -16,6 +16,7 @@ infinispan:
 bucket4j:
   enabled: true
   filter-config-caching-enabled: true
+  filter-config-cache-name: filterConfigCache
   filters:
   - id: filter1
     cache-name: buckets

--- a/examples/webflux-infinispan/src/test/resources/application-webflux-infinispan.yml
+++ b/examples/webflux-infinispan/src/test/resources/application-webflux-infinispan.yml
@@ -7,6 +7,7 @@ infinispan:
 bucket4j:
   enabled: true
   filter-config-caching-enabled: true
+  filter-config-cache-name: filterConfigCache
   filters:
   - id: filter1
     cache-name: buckets_test

--- a/examples/webflux/src/main/java/com/giffing/bucket4j/spring/boot/starter/examples/webflux/MyController.java
+++ b/examples/webflux/src/main/java/com/giffing/bucket4j/spring/boot/starter/examples/webflux/MyController.java
@@ -1,11 +1,13 @@
 package com.giffing.bucket4j.spring.boot.starter.examples.webflux;
 
 import com.giffing.bucket4j.spring.boot.starter.utils.Bucket4JUtils;
+import jakarta.annotation.Nullable;
 import jakarta.validation.ConstraintViolation;
 import jakarta.validation.Valid;
 import jakarta.validation.Validator;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.support.DefaultMessageSourceResolvable;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.*;
@@ -27,7 +29,7 @@ public class MyController {
 
 	private final CacheManager<String, Bucket4JConfiguration> configCacheManager;
 
-	public MyController(CacheManager<String, Bucket4JConfiguration> configCacheManager) {
+	public MyController(@Nullable CacheManager<String, Bucket4JConfiguration> configCacheManager) {
 		this.configCacheManager = configCacheManager;
 	}
 
@@ -60,6 +62,7 @@ public class MyController {
 	public ResponseEntity<?> updateConfig(
 		@PathVariable String filterId,
 		@RequestBody Bucket4JConfiguration newConfig) {
+		if(configCacheManager == null) return ResponseEntity.status(HttpStatus.FORBIDDEN).body("Dynamic updating is disabled");
 
 		//validate that the path id matches the body
 		if (!newConfig.getId().equals(filterId)) {

--- a/examples/webflux/src/main/resources/application.yml
+++ b/examples/webflux/src/main/resources/application.yml
@@ -6,16 +6,21 @@ management:
     web:
       exposure:
         include: "*"
-spring:  cache:    type: hazelcast
+spring:
+  cache:
+    type: hazelcast
 bucket4j:
   enabled: true
+  filter-config-caching-enabled: true
+  filter-config-cache-name: filterConfigCache
   filters:
   - cache-name: buckets
     filter-method: webflux
     url: .*
     http-content-type: application/json;charset=UTF-8
     http-response-body: '{ "name": "hello"}'
-    http-response-headers:      HELLO: WORLD
+    http-response-headers:
+      HELLO: WORLD
     filter-order: 1
     rate-limits:
     - execute-predicates:

--- a/examples/webflux/src/test/resources/application-webflux.yml
+++ b/examples/webflux/src/test/resources/application-webflux.yml
@@ -1,5 +1,7 @@
 bucket4j:
   enabled: true
+  filter-config-caching-enabled: true
+  filter-config-cache-name: filterConfigCache
   filters:
   - id: filter1
     cache-name: buckets_test


### PR DESCRIPTION
Issue #222 mentioned a nullpointer exception when starting the application. After investigating I discovered that this issue came from an unwanted 'matchIfMissing = true' on CacheListener and CacheManager bean instantiation conditions, which I overlooked during local testing. 

This pull request removes the unwanted matchIfMissing, and also includes an update of the example testclasses and properties files to make it easier to test it. 

Can be tested by removing the 'filter-config-caching-enabled' property from the application.yml and 'filterConfigCache' cache from the cache configuration in an example project and trying to run it. This should now work without problems. 