### PR TITLE
Change log level when retrying connection with redis on JedisCacheListener

### DIFF
--- a/bucket4j-spring-boot-starter/src/main/java/com/giffing/bucket4j/spring/boot/starter/config/cache/redis/jedis/JedisCacheListener.java
+++ b/bucket4j-spring-boot-starter/src/main/java/com/giffing/bucket4j/spring/boot/starter/config/cache/redis/jedis/JedisCacheListener.java
@@ -64,7 +64,7 @@ public class JedisCacheListener<K, V> extends JedisPubSub {
 
 					jedis.subscribe(this, updateChannel);
 				} catch (Exception e) {
-					log.error("Failed to connect the Jedis subscriber, attempting to reconnect in {} seconds. " +
+					log.warn("Failed to connect the Jedis subscriber, attempting to reconnect in {} seconds. " +
 							"Exception was: {}", (reconnectBackoffTimeMillis.get() /1000), e.getMessage());
 
 					// Cancel the reset of the backoff
@@ -80,6 +80,7 @@ public class JedisCacheListener<K, V> extends JedisPubSub {
 						reconnectBackoffTimeMillis.set(Math.min((reconnectBackoffTimeMillis.get() * 2), 30000));
 					} catch (InterruptedException ignored) {
 						// ignored, already interrupted so the while loop will stop
+						log.error("Failed to connect the Jedis subscriber. Exception was: {}",  e.getMessage());
 					}
 				}
 			}


### PR DESCRIPTION
## Issue
I believe that an attempt at retrying a connection should not be considered as an error, instead we maybe should consider error if the retry attempt fails. What do you think we change the level of the log to `WARN` and log error only if the retry is interrupted?

## Use case
On my team we consider log level `ERROR` a situation where we should act to fix, this is not one of these situations because the service "heals itself".
