### PR TITLE
Fixed post execute condition

### DIFF
--- a/bucket4j-spring-boot-starter/src/main/java/com/giffing/bucket4j/spring/boot/starter/filter/reactive/AbstractReactiveFilter.java
+++ b/bucket4j-spring-boot-starter/src/main/java/com/giffing/bucket4j/spring/boot/starter/filter/reactive/AbstractReactiveFilter.java
@@ -3,6 +3,7 @@ package com.giffing.bucket4j.spring.boot.starter.filter.reactive;
 import com.giffing.bucket4j.spring.boot.starter.context.ExpressionParams;
 import com.giffing.bucket4j.spring.boot.starter.context.RateLimitConditionMatchingStrategy;
 import com.giffing.bucket4j.spring.boot.starter.context.RateLimitResult;
+import com.giffing.bucket4j.spring.boot.starter.context.RateLimitResultWrapper;
 import com.giffing.bucket4j.spring.boot.starter.context.properties.FilterConfiguration;
 import lombok.Data;
 import lombok.extern.slf4j.Slf4j;
@@ -15,6 +16,7 @@ import reactor.core.publisher.Mono;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 
@@ -102,16 +104,15 @@ public class AbstractReactiveFilter {
 		}
 
 		return chain.apply(exchange)
-				.then(Mono.defer(() -> {
-					var postRateLimitMonos = Mono.<Void>empty();
-					filterConfig.getPostRateLimitChecks().forEach(rlc -> {
-						var wrapper = rlc.rateLimit(exchange.getRequest(), response);
-						if (wrapper != null && wrapper.getRateLimitResultCompletableFuture() != null) {
-							postRateLimitMonos
-									.and(Mono.fromFuture(wrapper.getRateLimitResultCompletableFuture()));
-						}
-					});
-					return postRateLimitMonos;
-				}));
+				.then(Mono.defer(() ->
+						Mono.when(
+								filterConfig.getPostRateLimitChecks().stream()
+										.map(rlc -> rlc.rateLimit(exchange.getRequest(), response))
+										.filter(Objects::nonNull)
+										.map(RateLimitResultWrapper::getRateLimitResultCompletableFuture)
+										.filter(Objects::nonNull)
+										.map(Mono::fromFuture)
+									.toList()
+                )));
 	}
 }

--- a/bucket4j-spring-boot-starter/src/test/java/com/giffing/bucket4j/spring/boot/starter/webflux/WebfluxRateLimitFilterTest.java
+++ b/bucket4j-spring-boot-starter/src/test/java/com/giffing/bucket4j/spring/boot/starter/webflux/WebfluxRateLimitFilterTest.java
@@ -65,7 +65,7 @@ class WebfluxRateLimitFilterTest {
 		when(exchange.getResponse()).thenReturn(serverHttpResponse);
 
 		chain = Mockito.mock(WebFilterChain.class);
-		//when(chain.filter(exchange)).thenReturn(Mono.empty());
+		when(chain.filter(exchange)).thenReturn(Mono.empty());
 
 		configuration = new FilterConfiguration<>();
 		configuration.setRateLimitChecks(Arrays.asList(rateLimitCheck1, rateLimitCheck2, rateLimitCheck3));

--- a/bucket4j-spring-boot-starter/src/test/java/com/giffing/bucket4j/spring/boot/starter/webflux/WebfluxRateLimitFilterTest.java
+++ b/bucket4j-spring-boot-starter/src/test/java/com/giffing/bucket4j/spring/boot/starter/webflux/WebfluxRateLimitFilterTest.java
@@ -1,9 +1,6 @@
 package com.giffing.bucket4j.spring.boot.starter.webflux;
 
-import com.giffing.bucket4j.spring.boot.starter.context.RateLimitCheck;
-import com.giffing.bucket4j.spring.boot.starter.context.RateLimitConditionMatchingStrategy;
-import com.giffing.bucket4j.spring.boot.starter.context.RateLimitResult;
-import com.giffing.bucket4j.spring.boot.starter.context.RateLimitResultWrapper;
+import com.giffing.bucket4j.spring.boot.starter.context.*;
 import com.giffing.bucket4j.spring.boot.starter.context.properties.FilterConfiguration;
 import com.giffing.bucket4j.spring.boot.starter.filter.reactive.ReactiveRateLimitException;
 import com.giffing.bucket4j.spring.boot.starter.filter.reactive.webflux.WebfluxWebFilter;
@@ -13,6 +10,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatusCode;
 import org.springframework.http.server.reactive.ServerHttpRequest;
 import org.springframework.http.server.reactive.ServerHttpResponse;
 import org.springframework.web.server.ServerWebExchange;
@@ -22,9 +20,12 @@ import reactor.core.publisher.Mono;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
@@ -36,6 +37,8 @@ class WebfluxRateLimitFilterTest {
 	private RateLimitCheck<ServerHttpRequest> rateLimitCheck1;
 	private RateLimitCheck<ServerHttpRequest> rateLimitCheck2;
 	private RateLimitCheck<ServerHttpRequest> rateLimitCheck3;
+
+	private PostRateLimitCheck<ServerHttpRequest, ServerHttpResponse> postRateLimitCheck;
 
 	private ServerWebExchange exchange;
 	private WebFilterChain chain;
@@ -49,6 +52,8 @@ class WebfluxRateLimitFilterTest {
 		rateLimitCheck2 = mock(RateLimitCheck.class);
 		rateLimitCheck3 = mock(RateLimitCheck.class);
 
+		postRateLimitCheck = mock(PostRateLimitCheck.class);
+
 		exchange = Mockito.mock(ServerWebExchange.class);
 
 		ServerHttpRequest serverHttpRequest = Mockito.mock(ServerHttpRequest.class);
@@ -60,10 +65,13 @@ class WebfluxRateLimitFilterTest {
 		when(exchange.getResponse()).thenReturn(serverHttpResponse);
 
 		chain = Mockito.mock(WebFilterChain.class);
-		when(chain.filter(exchange)).thenReturn(Mono.empty());
+		//when(chain.filter(exchange)).thenReturn(Mono.empty());
 
 		configuration = new FilterConfiguration<>();
 		configuration.setRateLimitChecks(Arrays.asList(rateLimitCheck1, rateLimitCheck2, rateLimitCheck3));
+		configuration.setPostRateLimitChecks(
+				Collections.singletonList(
+						postRateLimitCheck));
 		configuration.setUrl(".*");
 		filter = new WebfluxWebFilter(configuration);
 	}
@@ -134,14 +142,86 @@ class WebfluxRateLimitFilterTest {
 		verify(rateLimitCheck3, times(0)).rateLimit(any(), any());
 	}
 
+	@Test
+	void should_execute_rate_limit_check_after_main_filter() {
+		configuration.setStrategy(RateLimitConditionMatchingStrategy.ALL);
+
+		rateLimitConfig(10L, rateLimitCheck1);
+		rateLimitConfig(10L, rateLimitCheck2);
+		rateLimitConfig(10L, rateLimitCheck3);
+
+		var httpHeaders = Mockito.mock(HttpHeaders.class);
+		when(serverHttpResponse.getHeaders()).thenReturn(httpHeaders);
+		when(serverHttpResponse.getStatusCode()).thenReturn(HttpStatusCode.valueOf(200));
+
+		when(chain.filter(exchange))
+				.thenReturn(
+						Mono.defer(() -> {
+							when(serverHttpResponse.getStatusCode())
+									.thenReturn(HttpStatusCode.valueOf(401));
+							return Mono.empty();
+						}));
+
+		var statusCode =
+                new AtomicReference<>(
+                        serverHttpResponse.getStatusCode());
+		configurePostRateLimit(
+				postRateLimitCheck,
+				Mono.defer(() -> {
+							statusCode.set(
+									serverHttpResponse.getStatusCode());
+							return Mono.just(
+									createRateLimitResult(0L));
+						}
+						));
+
+		filter.filter(exchange, chain).block();
+
+		Assertions.assertEquals(
+				HttpStatusCode.valueOf(401),
+				statusCode.get());
+	}
+
+	public static <T> Supplier<CompletableFuture<T>> createLazyFuture(Supplier<Mono<T>> monoSupplier) {
+		return () -> monoSupplier.get().toFuture();
+	}
+
 	private void rateLimitConfig(Long remainingTokens, RateLimitCheck<ServerHttpRequest> rateLimitCheck) {
 		RateLimitResultWrapper consumptionHolder = Mockito.mock(RateLimitResultWrapper.class);
+		RateLimitResult rateLimitResult = createRateLimitResult(remainingTokens);
+		when(consumptionHolder.getRateLimitResultCompletableFuture())
+				.thenReturn(
+						CompletableFuture.completedFuture(rateLimitResult));
+		when(rateLimitCheck.rateLimit(any(), any())).thenReturn(consumptionHolder);
+	}
+
+	private void configurePostRateLimit(
+			PostRateLimitCheck<ServerHttpRequest, ServerHttpResponse> rateLimitCheck,
+			Long remainingTokens) {
+		configurePostRateLimit(
+				rateLimitCheck,
+					Mono.just(
+							createRateLimitResult(
+									remainingTokens)));
+	}
+
+	private void configurePostRateLimit(
+			PostRateLimitCheck<ServerHttpRequest, ServerHttpResponse> rateLimitCheck,
+			Mono<RateLimitResult> result) {
+		RateLimitResultWrapper consumptionHolder = Mockito.mock(RateLimitResultWrapper.class);
+
+		when(consumptionHolder.getRateLimitResultCompletableFuture())
+				.thenAnswer(invocation -> result.toFuture());
+		when(rateLimitCheck.rateLimit(any(), any())).thenReturn(consumptionHolder);
+	}
+
+	private RateLimitResult createRateLimitResult(
+			Long remainingTokens) {
 		RateLimitResult rateLimitResult = Mockito.mock(RateLimitResult.class);
 		when(rateLimitResult.isConsumed()).thenReturn(remainingTokens > 0);
 		when(rateLimitResult.getRemainingTokens()).thenReturn(remainingTokens);
-		when(consumptionHolder.getRateLimitResultCompletableFuture())
-				.thenReturn(CompletableFuture.completedFuture(rateLimitResult));
-		when(rateLimitCheck.rateLimit(any(), any())).thenReturn(consumptionHolder);
+
+		return rateLimitResult;
 	}
 
 }


### PR DESCRIPTION
This PR fixes the issue where rate limit checks were executed before the response status was available, causing them to always trigger with a 200 status.

Changes:
- Refactored rate limit logic to use `post-execute-condition`, ensuring rate limit checks occur after the response status is set.
- Used `Mono.defer()` to ensure rate limit checks are only executed when needed, avoiding unnecessary object creation and improving performance.
- Prevented rate limit checks from being executed in case of errors (e.g., network issues), ensuring they only run for valid responses.